### PR TITLE
Don't lock all of lvm on init/add-node

### DIFF
--- a/drbdmanage_client.py
+++ b/drbdmanage_client.py
@@ -3414,12 +3414,12 @@ Confirm:
 
         # Create the .drbdctrl LV
         self._ext_command(
-            ["lvcreate", "-n", drbdctrl_lv_0, "-L", "4m", drbdctrl_vg]
+            ["lvcreate", "-y", "-n", drbdctrl_lv_0, "-L", "4m", drbdctrl_vg]
         )
         wipefs(drbdctrl_blockdev_0)
 
         self._ext_command(
-            ["lvcreate", "-n", drbdctrl_lv_1, "-L", "4m", drbdctrl_vg]
+            ["lvcreate", "-y", "-n", drbdctrl_lv_1, "-L", "4m", drbdctrl_vg]
         )
         wipefs(drbdctrl_blockdev_1)
 


### PR DESCRIPTION
drbdmanage init/add-node does this:

  drbdsetup down .drbdctrl
  lvremove --force drbdpool/.drbdctrl_0
  lvremove --force drbdpool/.drbdctrl_1
  lvcreate -n .drbdctrl_0 -L 4m drbdpool
  lvcreate -n .drbdctrl_1 -L 4m drbdpool

Trouble is, lvcreate is an interactive tool unless explicitly told not
to be. Which on occasion leads to this:

  WARNING: drbdmanage_control_volume signature detected on
           /dev/drbdpool/.drbdctrl_1 at offset 0. Wipe it? [y/n]: y

lvcreate takes a global lock on all of lvm until you answer. And drbdmanage
gives no indication that lvcreate wants something from the operator. End
result: anything volume-related (even an lvs) blocks until the operator
notices and punches ctrl+c.

This patch fixes only this one instance of the problem, though a quick
grep indicates that the problem is present elsewhere as well. Somebody
*really* needs to go through all of the lvm command invocations and
apply a --yes/--force/--something and release a new version asap. At
present running drbdmanage on a production system is very risky.