### PR TITLE
Allow to set 'storage-plugin' in drbdmanaged.cfg

### DIFF
--- a/drbdmanage/utils.py
+++ b/drbdmanage/utils.py
@@ -593,6 +593,7 @@ def load_server_conf_file(localonly=False):
                 in_file_cfg = dict(cfg.items(section))
                 if not cfg.has_option(section, 'force'):
                     final_config = filter_allowed(in_file_cfg.copy(), (KEY_DRBDCTRL_VG,
+                                                                       'storage-plugin',
                                                                        'extend-path',
                                                                        KEY_LOGLEVEL,
                                                                        KEY_SAT_CFG_ROLE,


### PR DESCRIPTION
Otherwise no clean way to set it for initial node on 'drbdmanage init' so only default 'lvm.Lvm' is used. And no reliable way to even change it later. Not even said about automated intialization like via Ansible. If plugins options can be set  this way - why 'storage-plugin' not?